### PR TITLE
Made ptz-i18n required dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+## 0.3.3 (October 11, 2017)
+
+* Made ptz-i18n required dependency
+
 ## 0.3.2 (October 04, 2017)
 
 * 100% test coverage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-i18n",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Multi language feature for Gatsby",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --fix ./src",
@@ -23,7 +23,8 @@
   "author": "angeloocana.com",
   "license": "MIT",
   "dependencies": {
-    "graphql": "^0.11.7"
+    "graphql": "^0.11.7",
+    "ptz-i18n": "^0.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -42,8 +43,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "jest": "^21.2.1",
     "opn-cli": "^3.1.0",
-    "ptz-assert": "^1.6.8",
-    "ptz-i18n": "^0.1.2"
+    "ptz-assert": "^1.6.8"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
What I did to make and test this PR:

I created a new blank gatsby project, by running `gatsby new gatsby-site`, made sure it starts without issues. Next, I added latest version of `gatsby-plugin-i18n` to the fresh `gatsby-config.js` and ran `gatsby-develop` command again.

I moved `"ptz-i18n"` to main dependencies section in package.json to fix startup issues in newly created project.

Resolves #4 