### PR TITLE
solves issue #18 

### DIFF
--- a/packages/gatsby-plugin-i18n/src/getMarkdownPage.js
+++ b/packages/gatsby-plugin-i18n/src/getMarkdownPage.js
@@ -8,13 +8,15 @@
 const getMarkdownPage = (options, postPage) => edge => {
   const path = edge.node.fields.slug;
   const langKey = edge.node.fields.langKey;
+  const regexPath = edge.node.fields.path;
 
   return {
     path, // required
     component: postPage,
     context: {
       path,
-      langKey
+      langKey,
+      regexPath
     },
     layout: options.useLangKeyLayout ? langKey : null
   };

--- a/packages/gatsby-plugin-i18n/src/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n/src/onCreateNode.js
@@ -48,13 +48,12 @@ const onCreateNode = ({ node, boundActionCreators }, pluginOptions) => {
             name: 'langKey',
             value: slugAndLang.langKey
           });
+          createNodeField({
+            node,
+            name: 'path',
+            value: slugAndLang.path
+          });
         }
-
-        createNodeField({
-          node,
-          name: 'path',
-          value: slugAndLang.path
-        });
 
         createNodeField({
           node,

--- a/packages/gatsby-plugin-i18n/src/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n/src/onCreateNode.js
@@ -52,11 +52,18 @@ const onCreateNode = ({ node, boundActionCreators }, pluginOptions) => {
 
         createNodeField({
           node,
+          name: 'path',
+          value: slugAndLang.path
+        });
+
+        createNodeField({
+          node,
           name: 'slug',
           value: slugAndLang.slug
         });
 
-        return 'langKey and slug added';
+
+        return 'langKey, path and slug added';
       }, isInPagesPaths(options, filePath))
     )
     .merge();

--- a/packages/gatsby-plugin-i18n/src/onCreateNode.test.js
+++ b/packages/gatsby-plugin-i18n/src/onCreateNode.test.js
@@ -34,7 +34,7 @@ describe('onCreateNode', () => {
 
     const result = onCreateNode({ node, boundActionCreators });
 
-    equal(result, 'langKey and slug added');
+    equal(result, 'langKey, path and slug added');
     equal(calls, 2);
   });
 
@@ -72,7 +72,7 @@ describe('onCreateNode', () => {
 
     const result = onCreateNode({ node, boundActionCreators });
 
-    equal(result, 'langKey and slug added');
+    equal(result, 'langKey, path and slug added');
     equal(calls, 1);
   });
 

--- a/packages/ptz-i18n/src/getSlugAndLang.js
+++ b/packages/ptz-i18n/src/getSlugAndLang.js
@@ -41,9 +41,12 @@ const getSlugAndLang = curry((options, fileAbsolutePath) => {
         addSlash(fileName[0].replace('index', ''))
     );
 
+    const path = addSlash(fileName[0].replace('index', ''));
+
     return {
       slug,
       langKey,
+      path,
       redirectTo: slug === '/' ? addSlash(langKeyDefault) : null
     };
   });

--- a/packages/ptz-i18n/src/getSlugAndLang.test.js
+++ b/packages/ptz-i18n/src/getSlugAndLang.test.js
@@ -8,6 +8,7 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/pt/blog/test/',
       langKey: 'pt',
+      path: '/blog/test/',
       redirectTo: null
     };
 
@@ -20,6 +21,7 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/test/',
       langKey: 'any',
+      path: '/test/',
       redirectTo: null
     };
 
@@ -32,6 +34,7 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/pt/blog/',
       langKey: 'pt',
+      path: '/blog/',
       redirectTo: null
     };
 
@@ -44,6 +47,7 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/',
       langKey: 'en',
+      path: '/',
       redirectTo: '/en/'
     };
 
@@ -61,6 +65,7 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/pt/blog/test/',
       langKey: 'pt',
+      path: '/blog/test/',
       redirectTo: null
     };
 
@@ -77,6 +82,7 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/blog/test/',
       langKey: 'en',
+      path: '/blog/test/',
       redirectTo: null
     };
 
@@ -93,6 +99,7 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/pt/blog/',
       langKey: 'pt',
+      path: '/blog/',
       redirectTo: null
     };
 
@@ -109,6 +116,20 @@ describe('getSlugAndLang', () => {
     const expected = {
       slug: '/blog/',
       langKey: 'en',
+      path: '/blog/',
+      redirectTo: null
+    };
+
+    assert.deepEqual(slugAndLangKey, expected);
+  });
+
+  it('returns identifier path', () => {
+    const absoluteFilePath = '/what/ever/src/pages/test.en.md';
+    const slugAndLangKey = getSlugAndLang('any', absoluteFilePath);
+    const expected = {
+      slug: '/en/test/',
+      langKey: 'en',
+      path: '/test/',
       redirectTo: null
     };
 


### PR DESCRIPTION
as you guys [suggested.](https://github.com/angeloocana/gatsby-plugin-i18n/issues/18#issuecomment-349111909).
it's creates a `Page` for all missing translation files, base on
available  `langKeys`
```
    {
      resolve: 'gatsby-plugin-i18n',
      options: {
        langKeyForNull: 'any',
        langKeyDefault: 'en',
        langKeys: ['en', 'tr', 'zh'],
        useLangKeyLayout: true,
        markdownRemark: {
          postPage: 'src/templates/post.js',
          query: `
          {
            allMarkdownRemark {
              edges {
                node {
                  fields {
                    slug,
                    langKey
                    path
                  }
                }
              }
            }
          }
          `
        }
      }
    },

```
which allows us to prevent going down to `404.html` 
but since it's doesn't create a node. if you use traditional query the page you try to render will be throw error. 
so to be able to handle that.
```javascript
// export const pageQuery = graphql`
//   query blogpostbypath($path: String!) {
//     markdownRemark(fields: {slug: {eq: $path}}) {  # this will fail for the paths which translation file doesn't exist
//         title
//         til
//         draft
//       }
//     }
//   }
// `;
```
we need to change a bit template file.
```javascript
export const pageQuery = graphql`
  query blogpostbypath($regexPath: String!) {
    allMarkdownRemark( 
      filter: {
        fields: {
          path: {
            regex: $regexPath  # instead of  `eq`  use `regex` via `regexPath`.  
          }
        }
      }
    ) {
    	edges{
        node {
      		fields {
            langKey
            slug
            path
          }
          html
          excerpt
          frontmatter {
            title
            til
            draft
          }
        }
      }
    }
  }
`
```
this is where `regexPath` get handy for query all available translations of the file.
you guys can check my [template file](https://github.com/Necmttn/necmttn.github.io/blob/dev/packages/necmttn-gatsby/src/templates/post.js) 


