### PR TITLE
List plugin on Gatsby's website

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "codecov": "^3.0.0",
     "lerna": "^2.5.1"
   },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin"
+  ],
   "license": "MIT",
   "dependencies": {}
 }


### PR DESCRIPTION
Community plugins needs the "gatsby-plugin" keyword to show up in the search. 

see https://github.com/gatsbyjs/gatsby/issues/4394#issuecomment-371659310