### PR TITLE
Place generated 404 at root of build folder

### DIFF
--- a/packages/gatsby-plugin-i18n/src/onCreatePage.js
+++ b/packages/gatsby-plugin-i18n/src/onCreatePage.js
@@ -29,7 +29,15 @@ const onCreatePage = ({ page, boundActionCreators }, pluginOptions) => {
       const newPage = getNewPage(page, options);
 
       deletePage(page);
-      createPage(newPage);
+
+    if (page.path === '/404.html') {
+        createPage({
+          ...newPage,
+          path: `/404.html`
+        });
+      } else {
+        createPage(newPage);
+      }
 
       return 'Page created';
     })


### PR DESCRIPTION
Previously 404.html was getting moved to 404/index.html which meant it woudn't be delivered to the user on sites where you can't control which file the server sends as a 404 (eg github pages). 

This change places it in the root of the build folder with a filename of 404.html, which matches most servers expected location.

This implements the change Jaikant proposed here: https://github.com/angeloocana/gatsby-plugin-i18n/issues/24