### PR TITLE
Fixed a crash bug when placing posts in places other than `/src/pages`.

### DIFF
--- a/packages/gatsby-plugin-i18n-tags/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n-tags/onCreateNode.js
@@ -36,7 +36,7 @@ var onCreateNode = function onCreateNode(_ref, pluginOptions) {
 
   if (node.frontmatter && node.frontmatter.tags && node.fields && !node.fields.tagSlugs) {
 
-    var slugAndLang = (0, _ptzI18n.getSlugAndLang)(options.langKeyForNull, node.fileAbsolutePath);
+    var slugAndLang = (0, _ptzI18n.getSlugAndLang)(options, node.fileAbsolutePath);
 
     var tagSlugs = node.frontmatter.tags.map(function (tag) {
       return {

--- a/packages/gatsby-plugin-i18n-tags/src/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n-tags/src/onCreateNode.js
@@ -20,7 +20,7 @@ const onCreateNode = ({ node, boundActionCreators, getNode }, pluginOptions) => 
   if (node.frontmatter && node.frontmatter.tags &&
         node.fields && !node.fields.tagSlugs) {
 
-    const slugAndLang = getSlugAndLang(options.langKeyForNull, node.fileAbsolutePath);
+    const slugAndLang = getSlugAndLang(options, node.fileAbsolutePath);
 
     const tagSlugs = node.frontmatter.tags.map(
       tag => {


### PR DESCRIPTION
It's because that `onCreateNode` function passed incorrect type of the params to `ptz-i18n.getSlugAndLang` function.

Details: see #38