### PR TITLE
chore: make plugin compatible with Gatsby v2

### DIFF
--- a/packages/gatsby-plugin-i18n-readnext/createPages.js
+++ b/packages/gatsby-plugin-i18n-readnext/createPages.js
@@ -19,7 +19,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var createPages = function createPages(_ref, pluginOptions) {
   var graphql = _ref.graphql,
-      boundActionCreators = _ref.boundActionCreators,
+      actions = _ref.actions,
       getNode = _ref.getNode;
 
   var options = _extends({}, _defaultOptions.defaultOptions, pluginOptions);
@@ -35,7 +35,7 @@ var createPages = function createPages(_ref, pluginOptions) {
         var posts = result.data.allMarkdownRemark.edges.filter(_ramda2.default.path(['node', 'fields', 'langKey'])).map(function (edge) {
           return edge.node;
         });
-        var createNodeField = boundActionCreators.createNodeField;
+        var createNodeField = actions.createNodeField;
 
 
         posts.forEach(function (post) {

--- a/packages/gatsby-plugin-i18n-readnext/setFieldsOnGraphQLNodeType.js
+++ b/packages/gatsby-plugin-i18n-readnext/setFieldsOnGraphQLNodeType.js
@@ -18,7 +18,7 @@ var setFieldsOnGraphQLNodeType = function setFieldsOnGraphQLNodeType(args, plugi
   var options = _extends({}, _defaultOptions.defaultOptions, pluginOptions);
 
   return new Promise(function (resolve, reject) {
-    var createNodeField = args.boundActionCreators.createNodeField;
+    var createNodeField = args.actions.createNodeField;
 
 
     var posts = args.getNodes().filter(function (n) {

--- a/packages/gatsby-plugin-i18n-readnext/src/createPages.js
+++ b/packages/gatsby-plugin-i18n-readnext/src/createPages.js
@@ -2,7 +2,7 @@ import { defaultOptions } from './defaultOptions';
 import { getReadNext } from './getReadNext';
 import R from 'ramda';
 
-const createPages = ({ graphql, boundActionCreators, getNode }, pluginOptions) => {
+const createPages = ({ graphql, actions, getNode }, pluginOptions) => {
   const options = {
     ...defaultOptions,
     ...pluginOptions
@@ -38,7 +38,7 @@ const createPages = ({ graphql, boundActionCreators, getNode }, pluginOptions) =
         const posts = result.data.allMarkdownRemark.edges
           .filter(R.path(['node', 'fields', 'langKey']))
           .map(edge => edge.node);
-        const { createNodeField } = boundActionCreators;
+        const { createNodeField } = actions;
 
         posts.forEach(post => {
           const readNextPosts = getReadNext(options.nPosts, post, posts)

--- a/packages/gatsby-plugin-i18n-readnext/src/setFieldsOnGraphQLNodeType.js
+++ b/packages/gatsby-plugin-i18n-readnext/src/setFieldsOnGraphQLNodeType.js
@@ -11,7 +11,7 @@ const setFieldsOnGraphQLNodeType = (args, pluginOptions) => {
   };
   
   return new Promise(function (resolve, reject) {
-    const { createNodeField } = args.boundActionCreators;
+    const { createNodeField } = args.actions;
   
     const posts = args.getNodes().filter(n => n.fields && n.fields.langKey && !n.fields.readNextPosts);
   

--- a/packages/gatsby-plugin-i18n-tags/createPages.js
+++ b/packages/gatsby-plugin-i18n-tags/createPages.js
@@ -27,8 +27,8 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var createPages = function createPages(_ref, pluginOptions) {
   var graphql = _ref.graphql,
-      boundActionCreators = _ref.boundActionCreators;
-  var createPage = boundActionCreators.createPage;
+      actions = _ref.actions;
+  var createPage = actions.createPage;
 
   var options = _extends({}, _defaultOptions.defaultOptions, pluginOptions);
 

--- a/packages/gatsby-plugin-i18n-tags/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n-tags/onCreateNode.js
@@ -25,13 +25,13 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  */
 var onCreateNode = function onCreateNode(_ref, pluginOptions) {
   var node = _ref.node,
-      boundActionCreators = _ref.boundActionCreators,
+      actions = _ref.actions,
       getNode = _ref.getNode;
 
 
   var options = _extends({}, _defaultOptions.defaultOptions, pluginOptions);
 
-  var createNodeField = boundActionCreators.createNodeField;
+  var createNodeField = actions.createNodeField;
 
 
   if (node.frontmatter && node.frontmatter.tags && node.fields && !node.fields.tagSlugs) {

--- a/packages/gatsby-plugin-i18n-tags/src/createPages.js
+++ b/packages/gatsby-plugin-i18n-tags/src/createPages.js
@@ -4,8 +4,8 @@ import path from 'path';
 import {logError} from './logError';
 import R from 'ramda';
 
-const createPages = ({ graphql, boundActionCreators }, pluginOptions) => {
-  const { createPage } = boundActionCreators;
+const createPages = ({ graphql, actions }, pluginOptions) => {
+  const { createPage } = actions;
   const options = {
     ...defaultOptions,
     ...pluginOptions

--- a/packages/gatsby-plugin-i18n-tags/src/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n-tags/src/onCreateNode.js
@@ -8,14 +8,14 @@ import { getSlugAndLang } from 'ptz-i18n';
  * @param {*} pluginOptions plugin options from gatsby-config.js
  * @returns {void}
  */
-const onCreateNode = ({ node, boundActionCreators, getNode }, pluginOptions) => {
+const onCreateNode = ({ node, actions, getNode }, pluginOptions) => {
 
   const options = {
     ...defaultOptions,
     ...pluginOptions
   };
 
-  const { createNodeField } = boundActionCreators;
+  const { createNodeField } = actions;
 
   if (node.frontmatter && node.frontmatter.tags &&
         node.fields && !node.fields.tagSlugs) {

--- a/packages/gatsby-plugin-i18n/src/createPages.js
+++ b/packages/gatsby-plugin-i18n/src/createPages.js
@@ -16,8 +16,8 @@ const createPages = (_, pluginOptions) => {
     ...pluginOptions
   };
 
-  const { graphql, boundActionCreators } = _;
-  const { createPage } = boundActionCreators;
+  const { graphql, actions } = _;
+  const { createPage } = actions;
 
   return new Promise((resolve, reject) => {
     const postPage = path.resolve(options.markdownRemark.postPage);

--- a/packages/gatsby-plugin-i18n/src/createPages.test.js
+++ b/packages/gatsby-plugin-i18n/src/createPages.test.js
@@ -4,14 +4,14 @@ import * as assert from 'ptz-assert';
 describe('createPages', () => {
   it('return null when no options.markdownRemark', () => {
     const graphql = () => null;
-    const boundActionCreators = {
+    const actions = {
       createPage: () => null
     };
     const pluginOptions = {
 
     };
 
-    const result = createPages({ graphql, boundActionCreators }, pluginOptions);
+    const result = createPages({ graphql, actions }, pluginOptions);
     assert.notOk(result);
   });
 
@@ -47,7 +47,7 @@ describe('createPages', () => {
     });
 
     let pagesCreated = 0;
-    const boundActionCreators = {
+    const actions = {
       createPage: () => { pagesCreated += 1; }
     };
     const pluginOptions = {
@@ -70,7 +70,7 @@ describe('createPages', () => {
       }
     };
 
-    createPages({ graphql, boundActionCreators }, pluginOptions)
+    createPages({ graphql, actions }, pluginOptions)
       .then(() => {
         assert.equal(pagesCreated, 2);
         done();
@@ -82,7 +82,7 @@ describe('createPages', () => {
       errors: ['error test']
     });
 
-    const boundActionCreators = {
+    const actions = {
       createPage: () => null
     };
 
@@ -106,7 +106,7 @@ describe('createPages', () => {
       }
     };
 
-    createPages({ graphql, boundActionCreators }, pluginOptions)
+    createPages({ graphql, actions }, pluginOptions)
       .catch(() => done());
   });
 });

--- a/packages/gatsby-plugin-i18n/src/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n/src/onCreateNode.js
@@ -23,7 +23,7 @@ const getFilePath = node => {
  * @param {*} pluginOptions plugin options from gatsby-config.js
  * @returns {void} void
  */
-const onCreateNode = ({ node, boundActionCreators }, pluginOptions) => {
+const onCreateNode = ({ node, actions }, pluginOptions) => {
 
   const options = {
     ...defaultOptions,
@@ -40,7 +40,7 @@ const onCreateNode = ({ node, boundActionCreators }, pluginOptions) => {
 
         const slugAndLang = getSlugAndLang(options, filePath);
 
-        const { createNodeField } = boundActionCreators;
+        const { createNodeField } = actions;
 
         if(node.internal.type === 'MarkdownRemark'){
           createNodeField({

--- a/packages/gatsby-plugin-i18n/src/onCreateNode.test.js
+++ b/packages/gatsby-plugin-i18n/src/onCreateNode.test.js
@@ -14,7 +14,7 @@ describe('onCreateNode', () => {
 
     let calls = 0;
 
-    const boundActionCreators = {
+    const actions = {
       createNodeField: (field) => {
         if (field.name === 'slug') {
           const expectedField = {
@@ -32,7 +32,7 @@ describe('onCreateNode', () => {
       }
     };
 
-    const result = onCreateNode({ node, boundActionCreators });
+    const result = onCreateNode({ node, actions });
 
     equal(result, 'langKey and slug added');
     equal(calls, 2);
@@ -51,7 +51,7 @@ describe('onCreateNode', () => {
 
     let calls = 0;
 
-    const boundActionCreators = {
+    const actions = {
       createNodeField: (field) => {
         if (field.name === 'slug') {
           const expectedField = {
@@ -70,7 +70,7 @@ describe('onCreateNode', () => {
       }
     };
 
-    const result = onCreateNode({ node, boundActionCreators });
+    const result = onCreateNode({ node, actions });
 
     equal(result, 'langKey and slug added');
     equal(calls, 1);
@@ -86,13 +86,13 @@ describe('onCreateNode', () => {
 
     let calls = 0;
 
-    const boundActionCreators = {
+    const actions = {
       createNodeField: (field) => {
         calls += 1;
       }
     };
 
-    const result = onCreateNode({ node, boundActionCreators });
+    const result = onCreateNode({ node, actions });
 
     equal(calls, 0);
     equal(result, 'Skipping page, not in pagesPaths');
@@ -104,13 +104,13 @@ describe('onCreateNode', () => {
         type: 'other'
       }
     };
-    const boundActionCreators = {
+    const actions = {
       createNodeField: (args) => {
         throw (args);
       }
     };
 
-    const result = onCreateNode({ node, boundActionCreators });
+    const result = onCreateNode({ node, actions });
 
     equal(result, 'Skiping file type: other');
   });

--- a/packages/gatsby-plugin-i18n/src/onCreatePage.js
+++ b/packages/gatsby-plugin-i18n/src/onCreatePage.js
@@ -8,7 +8,7 @@ import { isInPagesPaths } from 'ptz-i18n';
  * @param {*} pluginOptions plugin options from gatsby-config.js
  * @returns {Promise} Promise
  */
-const onCreatePage = ({ page, boundActionCreators }, pluginOptions) => {
+const onCreatePage = ({ page, actions }, pluginOptions) => {
   if (page.context.slug) {
     return 'Skipping page already has slug'; // Allow only pages without slug
   }
@@ -24,7 +24,7 @@ const onCreatePage = ({ page, boundActionCreators }, pluginOptions) => {
         return 'Skipping page, not in pagesPaths';
       }
 
-      const { createPage, deletePage } = boundActionCreators;
+      const { createPage, deletePage } = actions;
 
       const newPage = getNewPage(page, options);
 

--- a/packages/gatsby-plugin-i18n/src/onCreatePage.test.js
+++ b/packages/gatsby-plugin-i18n/src/onCreatePage.test.js
@@ -25,7 +25,7 @@ describe('onCreatePage', () => {
       layout: 'en'
     };
 
-    const boundActionCreators = {
+    const actions = {
       createPage: (page) => {
         assert.deepEqual(page, expectedPage);
         done();
@@ -33,7 +33,7 @@ describe('onCreatePage', () => {
       deletePage: ({ path }) => assert.equal(path, oldPath)
     };
 
-    const result = onCreatePage({ page: oldPage, boundActionCreators }, options);
+    const result = onCreatePage({ page: oldPage, actions }, options);
 
     assert.equal(result, 'Page created');
   });
@@ -61,7 +61,7 @@ describe('onCreatePage', () => {
       layout: undefined // eslint-disable-line no-undefined
     };
 
-    const boundActionCreators = {
+    const actions = {
       createPage: (page) => {
         assert.deepEqual(page, expectedPage);
         done();
@@ -69,7 +69,7 @@ describe('onCreatePage', () => {
       deletePage: ({ path }) => assert.equal(path, oldPath)
     };
 
-    const result = onCreatePage({ page: oldPage, boundActionCreators }, options);
+    const result = onCreatePage({ page: oldPage, actions }, options);
 
     assert.equal(result, 'Page created');
   });
@@ -82,12 +82,12 @@ describe('onCreatePage', () => {
       componentPath: '/angeloocana/pages/test.en.js'
     };
 
-    const boundActionCreators = {
+    const actions = {
       createPage: () => { throw new Error('can not call createPage'); },
       deletePage: () => { throw new Error('can not call deletePage'); }
     };
 
-    const result = onCreatePage({ page, boundActionCreators });
+    const result = onCreatePage({ page, actions });
 
     assert.equal(result, 'Skipping page already has slug');
   });
@@ -99,12 +99,12 @@ describe('onCreatePage', () => {
       componentPath: '/angeloocana/test.en.js'
     };
 
-    const boundActionCreators = {
+    const actions = {
       createPage: () => { throw new Error('can not call createPage'); },
       deletePage: () => { throw new Error('can not call deletePage'); }
     };
 
-    const result = onCreatePage({ page, boundActionCreators });
+    const result = onCreatePage({ page, actions });
 
     assert.equal(result, 'Skipping page, not in pagesPaths');
   });


### PR DESCRIPTION
This PR is just making `gatsby-plugin-i18n` compatible with Gatsby v2. No work has yet been done on updating the `gatsby-starter-default-i18n` package. 