### PR TITLE
Moving to slug instead of path in the context

### DIFF
--- a/packages/gatsby-plugin-i18n/src/getMarkdownPage.js
+++ b/packages/gatsby-plugin-i18n/src/getMarkdownPage.js
@@ -7,13 +7,15 @@
  */
 const getMarkdownPage = (options, postPage) => edge => {
   const path = edge.node.fields.slug;
+  const slug = edge.node.fields.slug;
   const langKey = edge.node.fields.langKey;
 
   return {
     path, // required
     component: postPage,
     context: {
-      path,
+      path, // For backward compatibility only...
+      slug,
       langKey
     },
     layout: options.useLangKeyLayout ? langKey : null


### PR DESCRIPTION
Using the `path` property name in the context generates a warning as mentioned in the issue #35.
Nb.: This MR doesn't necessarily covers all the cases of this issue, only the warnings generates for markup pages.