### PR TITLE
fix: fix package.json files to show readme on gatsbyjs.org

### DIFF
--- a/packages/gatsby-plugin-i18n-readnext/package.json
+++ b/packages/gatsby-plugin-i18n-readnext/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-plugin-i18n-readnext",
   "version": "0.0.4",
   "description": "Read Next feature for multi language gatsby projects",
-  "homepage": "https://github.com/angeloocana/gatsby-plugin-i18n-readnext#readme",
+  "homepage": "https://github.com/angeloocana/gatsby-plugin-i18n/tree/master/packages/gatsby-plugin-i18n-readnext#readme",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --fix ./src",
     "prebuild": "yarn run lint",
@@ -12,9 +12,10 @@
     "test": "jest",
     "coverage": "codecov"
   },
-  "respository": {
+  "repository": {
     "type": "git",
-    "url": "https://github.com/angeloocana/gatsby-plugin-i18n-readnext"
+    "url": "https://github.com/angeloocana/gatsby-plugin-i18n.git",
+    "directory": "packages/gatsby-plugin-i18n-readnext"
   },
   "keywords": [
     "gatsby",
@@ -56,7 +57,6 @@
       "transform-object-rest-spread"
     ]
   },
-  "readme": "README.md",
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true

--- a/packages/gatsby-plugin-i18n-tags/package.json
+++ b/packages/gatsby-plugin-i18n-tags/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-plugin-i18n-tags",
   "version": "1.0.0",
   "description": "Multi language feature for Gatsby",
-  "homepage": "https://github.com/angeloocana/gatsby-plugin-i18n-tags#readme",
+  "homepage": "https://github.com/angeloocana/gatsby-plugin-i18n/tree/master/packages/gatsby-plugin-i18n-tags#readme",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --fix ./src",
     "prebuild": "yarn run lint",
@@ -12,9 +12,10 @@
     "test": "jest",
     "coverage": "codecov"
   },
-  "respository": {
+  "repository": {
     "type": "git",
-    "url": "https://github.com/angeloocana/gatsby-plugin-i18n-tags"
+    "url": "https://github.com/angeloocana/gatsby-plugin-i18n.git",
+    "directory": "packages/gatsby-plugin-i18n-tags"
   },
   "keywords": [
     "gatsby",
@@ -54,7 +55,6 @@
       "transform-object-rest-spread"
     ]
   },
-  "readme": "README.md",
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-plugin-i18n",
   "version": "1.0.1",
   "description": "Multi language feature for Gatsby",
-  "homepage": "https://github.com/angeloocana/gatsby-plugin-i18n#readme",
+  "homepage": "https://github.com/angeloocana/gatsby-plugin-i18n/tree/master/packages/gatsby-plugin-i18n#readme",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --fix ./src",
     "prebuild": "yarn run lint",
@@ -12,9 +12,10 @@
     "coverage": "codecov",
     "test:open": "opn ./coverage/lcov-report/index.html"
   },
-  "respository": {
+  "repository": {
     "type": "git",
-    "url": "https://github.com/angeloocana/gatsby-plugin-i18n"
+    "url": "https://github.com/angeloocana/gatsby-plugin-i18n.git",
+    "directory": "packages/gatsby-plugin-i18n"
   },
   "keywords": [
     "gatsby",
@@ -55,7 +56,6 @@
       "transform-object-rest-spread"
     ]
   },
-  "readme": "README.md",
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,

--- a/packages/ptz-i18n/package.json
+++ b/packages/ptz-i18n/package.json
@@ -2,7 +2,7 @@
   "name": "ptz-i18n",
   "version": "1.0.0",
   "description": "I18n functions to be used with Gatsby projects.",
-  "homepage": "https://github.com/angeloocana/ptz-i18n#readme",
+  "homepage": "https://github.com/angeloocana/gatsby-plugin-i18n/tree/master/packages/ptz-i18n#readme",
   "main": "dist/index.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --fix ./src",
@@ -15,9 +15,10 @@
     "test:watch": "jest --watch",
     "test:open": "opn ./coverage/lcov-report/index.html"
   },
-  "respository": {
+  "repository": {
     "type": "git",
-    "url": "https://github.com/angeloocana/ptz-i18n"
+    "url": "https://github.com/angeloocana/gatsby-plugin-i18n.git",
+    "directory": "packages/ptz-i18n"
   },
   "keywords": [
     "gatsby",
@@ -59,7 +60,6 @@
       "spec.js,test.js"
     ]
   },
-  "readme": "README.md",
   "jest": {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,


### PR DESCRIPTION
When we view your plugins on https://gatsbyjs.org/ we see an readme called README.md. I've updated your package.json to be more compatible with npm & our gatsby site.