### PR TITLE
Fix bug in isHomePage method when using prefixDefault set to false

### DIFF
--- a/packages/ptz-i18n/package-lock.json
+++ b/packages/ptz-i18n/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ptz-i18n",
-	"version": "0.4.0",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1588,7 +1588,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"contains-path": {
 			"version": "0.1.0",
@@ -4724,6 +4725,7 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
@@ -4733,13 +4735,15 @@
 					"version": "5.1.2",
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -6095,7 +6099,8 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -6138,7 +6143,8 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
@@ -6149,7 +6155,8 @@
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -6266,7 +6273,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -6278,6 +6286,7 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -6300,12 +6309,14 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.2.4",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.1",
 								"yallist": "^3.0.0"
@@ -6324,6 +6335,7 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -6404,7 +6416,8 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -6416,6 +6429,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -6501,7 +6515,8 @@
 						"safe-buffer": {
 							"version": "5.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -6537,6 +6552,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -6556,6 +6572,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -6599,12 +6616,14 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						}
 					}
 				},

--- a/packages/ptz-i18n/src/index.js
+++ b/packages/ptz-i18n/src/index.js
@@ -13,39 +13,47 @@ import isInPagesPaths from './isInPagesPaths';
  * @param {*} url pathName
  * @returns {Number} number of paths
  */
-const nPaths = url => (url.match(/\//g) || []).length - 1;
+const nPaths = url => url.split('/').filter(Boolean).length;
 
 /**
  * Checks if the url is /, /en/ or /pt/
  * @param {*} url this.props.location
+ * @param {Boolean} prefixDefault: boolean indicating whether the the urls for the default lang should be prefix or not
+ * @param {[String]} langs lang keys ['en', 'fr', 'pt']
  * @returns {Boolean} is home or not
  */
-const isHomePage = url => nPaths(url) <= 1;
+const isHomePage = (url, prefixDefault = true, langs) => {
+  if (prefixDefault) {
+    if (langs) {
+      return nPaths(url) <= 1 && langs.includes(url.split('/').filter(Boolean)[0]);
+    } else {
+      return nPaths(url) <= 1;
+    }
+  } else {
+    return nPaths(url) === 0 || (nPaths(url) === 1 && langs.includes(url.split('/').filter(Boolean)[0]));
+  }
+};
 
 /**
  * Add lang to slug
  * @param {String} slug  Slug to add lang
  * @param {String} langKey langKey to add
- * @param {{langKeyDefault: string, prefixDefault: boolean }} options prefixDefault: boolean indicating whether the the urls for the default land should be prefix or not
+ * @param {{langKeyDefault: string, prefixDefault: boolean }} options prefixDefault: boolean indicating whether the the urls for the default lang should be prefix or not
  * @returns {String} new slug
  */
 const addLangKeyToSlug = curry((slug, langKey, options) => {
-  return langKey !== options.langKeyDefault || options.prefixDefault
-    ? `/${langKey}${slug}`
-    : `${slug}`;
+  return langKey !== options.langKeyDefault || options.prefixDefault ? `/${langKey}${slug}` : `${slug}`;
 });
 
 /**
  * Get url to the language
- * @param {String} homeLink  link for the home page
+ * @param {String} homeLink  link to the home page
  * @param {String} url  browser url
  * @param {String} langKey default browser language key
  * @returns {String} new url
  */
 const getUrlForLang = curry((homeLink, url, langKey) => {
-  return url === '/' || !startsWith(homeLink, url)
-    ? `/${langKey}/`
-    : url.replace(homeLink, `/${langKey}/`);
+  return url === '/' || !startsWith(homeLink, url) ? `/${langKey}/` : url.replace(homeLink, `/${langKey}/`);
 });
 
 /**
@@ -71,9 +79,7 @@ const getLangs = curry((langs, currentLangKey, getUrlForLang) => {
  * @param {*} langKey langKey
  * @returns {*} i18n[langKey] or i18n[defaultLangKey]
  */
-const getI18nBase = curry(
-  (i18n, langKey) => i18n[langKey] || Object.values(i18n)[0]
-);
+const getI18nBase = curry((i18n, langKey) => i18n[langKey] || Object.values(i18n)[0]);
 
 export {
   addLangKeyToSlug,

--- a/packages/ptz-i18n/src/index.test.js
+++ b/packages/ptz-i18n/src/index.test.js
@@ -1,13 +1,24 @@
-import {
-  addLangKeyToSlug,
-  getLangs,
-  getUrlForLang,
-  getI18nBase,
-  isHomePage
-} from './index';
+import { addLangKeyToSlug, getLangs, getUrlForLang, getI18nBase, isHomePage, nPaths } from './index';
 import * as assert from 'ptz-assert';
 
 describe('langs', () => {
+  describe('nPaths', () => {
+    it('returns the correct number of paths', () => {
+      assert.equal(nPaths('/en/contact/'), 2);
+    });
+    it('one path one slash', () => {
+      assert.equal(nPaths('/en'), 1);
+    });
+    it('one path', () => {
+      assert.equal(nPaths('/en/'), 1);
+    });
+    it('no paths', () => {
+      assert.equal(nPaths('/'), 0);
+    });
+    it('empty path', () => {
+      assert.equal(nPaths(''), 0);
+    });
+  });
   describe('addLangKeyToSlug', () => {
     it('should add lang key to slug', () => {
       const slug = '/about/';
@@ -18,13 +29,13 @@ describe('langs', () => {
     it('should omit the lang key in the slug when prefixDefault is false', () => {
       const slug = '/about/';
       const langKey = 'en';
-      const options = {langKeyDefault: 'en', prefixDefault: false};
+      const options = { langKeyDefault: 'en', prefixDefault: false };
       assert.equal(addLangKeyToSlug(slug, langKey, options), '/about/');
     });
     it('should add the lang key in the slug when prefixDefault is true', () => {
       const slug = '/about/';
       const langKey = 'en';
-      const options = {langKeyDefault: 'en', prefixDefault: true};
+      const options = { langKeyDefault: 'en', prefixDefault: true };
       assert.equal(addLangKeyToSlug(slug, langKey, options), '/en/about/');
     });
   });
@@ -73,18 +84,21 @@ describe('langs', () => {
       const langs = getLangs(['en', 'fr', 'pt'], 'en', getUrlForLang('/en/', '/'));
       const expected = [
         {
-          'langKey': 'en',
-          'link': '/en/',
-          'selected': true
-        }, {
-          'langKey': 'fr',
-          'link': '/fr/',
-          'selected': false
-        }, {
-          'langKey': 'pt',
-          'link': '/pt/',
-          'selected': false
-        }];
+          langKey: 'en',
+          link: '/en/',
+          selected: true
+        },
+        {
+          langKey: 'fr',
+          link: '/fr/',
+          selected: false
+        },
+        {
+          langKey: 'pt',
+          link: '/pt/',
+          selected: false
+        }
+      ];
       assert.deepEqual(langs, expected);
     });
   });
@@ -113,6 +127,7 @@ describe('langs', () => {
   });
 
   describe('isHomePage', () => {
+    const langs = ['en', 'pt', 'fr'];
     it('/ true', () => {
       assert.ok(isHomePage('/'));
     });
@@ -125,6 +140,14 @@ describe('langs', () => {
     it('/en/tags/ false', () => {
       assert.notOk(isHomePage('/en/tags/'));
     });
+    it('/contact/ !prefixDefault false', () => {
+      assert.notOk(isHomePage('/contact/', false, langs));
+    });
+    it('/contact/ !prefixDefault true', () => {
+      assert.notOk(isHomePage('/contact/', true, langs));
+    });
+    it('/en/ !prefixDefault true', () => {
+      assert.ok(isHomePage('/en/', false, langs));
+    });
   });
 });
-


### PR DESCRIPTION
The method isHomePage was not considering the case where the url's may not have the default language, like in the example: `/contact/` instead of `/en/contact`. 

This PR adds the functionality, keeping all the previous use cases compatible. 
Test cases for all scenarios are added. 