### PR TITLE
Language links rewrites

### DIFF
--- a/packages/gatsby-starter-default-i18n/src/layouts/index.js
+++ b/packages/gatsby-starter-default-i18n/src/layouts/index.js
@@ -27,7 +27,7 @@ const Layout = ({ children, location, i18nMessages }) => {
         const url = location.pathname;
         const { langs, defaultLangKey } = data.site.siteMetadata.languages;
         const langKey = getCurrentLangKey(langs, defaultLangKey, url);
-        const homeLink = `/${langKey}`.replace(`/${defaultLangKey}/`, '/');
+        const homeLink = `/${langKey}/`.replace(`/${defaultLangKey}/`, '/');
         const langsMenu = getLangs(langs, langKey, getUrlForLang(homeLink, url)).map((item) => ({ ...item, link: item.link.replace(`/${defaultLangKey}/`, '/') }));
         return (
           <IntlProvider


### PR DESCRIPTION
This fixes an issue with wrong url's generated in the language links.

go to the root (default language 'en')
click on 'Go to page 2'
click on 'pt'
desired outcome: /pt/page-2
generated outcome: /pt

When adding the trailing slash, the generated outcome is '/pt/page-2'