### PR TITLE
feat(gatsby-plugin-i18n-tags): mdx support

### DIFF
--- a/packages/gatsby-plugin-i18n-tags/src/createPages.js
+++ b/packages/gatsby-plugin-i18n-tags/src/createPages.js
@@ -21,7 +21,8 @@ const createPages = ({ graphql, actions }, pluginOptions) => {
           throw result.errors;
         }
   
-        const langTags = result.data.allMarkdownRemark.edges
+        const resultData = result.data.allMarkdownRemark || result.data.allMdx;
+        const langTags = resultData.edges
           .filter(R.path(['node', 'fields', 'langKey']))
           .reduce((tags, edge) => {
             const langKey = edge.node.fields.langKey;

--- a/packages/gatsby-plugin-i18n/src/onCreateNode.js
+++ b/packages/gatsby-plugin-i18n/src/onCreateNode.js
@@ -43,7 +43,7 @@ const onCreateNode = ({ node, actions }, pluginOptions) => {
 
         if (
           node.internal.type === 'MarkdownRemark' ||
-          node.internal.type === 'Mdx'
+          node.internal.type === "Mdx"
         ) {
           createNodeField({
             node,


### PR DESCRIPTION
Look for alternative mdx query result property so the provided plugin query option can also be:
e.g.
```
query: `
            {
              allMdx {
                edges {
                  node {
                    fields {
                      slug,
                      langKey
                    }
                    frontmatter {
                      tags
                    }
                  }
                }
              }
            }
          `
```