### PR TITLE
fix http warnings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/0b3a917c0cb9433cb12eec33b989c723)](https://www.codacy.com/app/angeloocana/gatsby-plugin-i18n?utm_source=github.com&utm_medium=referral&utm_content=angeloocana/gatsby-plugin-i18n&utm_campaign=badger)
 [![Build Status](https://travis-ci.org/angeloocana/gatsby-plugin-i18n.svg?branch=master)](https://travis-ci.org/angeloocana/gatsby-plugin-i18n)
 [![NPM](https://img.shields.io/npm/v/gatsby-plugin-i18n.svg)](https://www.npmjs.com/package/gatsby-plugin-i18n)
-[![codecov.io](http://codecov.io/github/angeloocana/gatsby-plugin-i18n/coverage.svg)](http://codecov.io/github/angeloocana/gatsby-plugin-i18n)
+[![codecov.io](https://codecov.io/github/angeloocana/gatsby-plugin-i18n/coverage.svg)](https://codecov.io/github/angeloocana/gatsby-plugin-i18n)
 [![Dependency Status](https://gemnasium.com/angeloocana/gatsby-plugin-i18n.svg)](https://gemnasium.com/angeloocana/gatsby-plugin-i18n)
-[![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![MIT license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 
 Hi Folks!
 


### PR DESCRIPTION
Hey there, this plugin README has some http image URLs in it, which cause insecure content warnings on gatsbyjs.org when the plugin is indexed on the Gatsby plugin library. I fixed the URLs in this PR, so hopefully that can help to get it resolved. Thanks!