### PR TITLE
fix: add missing dependency ramda

### DIFF
--- a/packages/gatsby-plugin-i18n/package-lock.json
+++ b/packages/gatsby-plugin-i18n/package-lock.json
@@ -5653,6 +5653,13 @@
 			"requires": {
 				"folktale": "^2.0.1",
 				"ramda": "^0.24.1"
+			},
+			"dependencies": {
+				"ramda": {
+					"version": "0.24.1",
+					"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
+					"integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc="
+				}
 			}
 		},
 		"ptz-log": {

--- a/packages/gatsby-plugin-i18n/package.json
+++ b/packages/gatsby-plugin-i18n/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "folktale": "^2.0.1",
     "graphql": "^0.11.7",
-    "ptz-i18n": "^1.0.0"
+    "ptz-i18n": "^1.0.0",
+    "ramda": "^0.24.1"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`gatsby-plugin-i18n` is trying to use `ramda` without declaring it as a dependency

**How did you fix it?**

Added `ramda` as a dependency