### PR TITLE
docs: add new showcase reference on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Websites built with Gatsby i18n:
 * [tic-tac-toe-ai.surge.sh](https://tic-tac-toe-ai.surge.sh) [(source)](https://github.com/angeloocana/tic-tac-toe-ai)
 * [Imagine Clarity](https://imagineclarity.com)
 * [Peintagone](https://www.peintagone.be)
+* [jlozovei.dev](https://jlozovei.dev/) [(source)](https://github.com/jlozovei/me)
 
 Feel free to add your project to the list, we would love to see what you are building!
 


### PR DESCRIPTION
I'm adding the reference of my personal blog, [jlozovei.dev](https://jlozovei.dev/), on the readme _Showcase_ section.

While developing my blog's new version using Gatsby and the i18n plugin, I found the Hugo Magalhães website reference on readme and it helped me figure out how to organize my translated posts.
Then I added my blog's reference so that people can have one more resource to use. :star2: